### PR TITLE
Fix Next.js config and 404 page for production build

### DIFF
--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -7,7 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const nextConfig = {
   reactStrictMode: true,
   typedRoutes: false,
-  outputFileTracingRoot: path.resolve(__dirname, '..'),
+  // outputFileTracingRoot intentionally omitted to avoid interfering with app/src special routes
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/front/src/app/(shop)/catalog/page.tsx
+++ b/front/src/app/(shop)/catalog/page.tsx
@@ -3,10 +3,8 @@ import fs from 'fs';
 import React from 'react';
 import { Product } from '../../../entities';
 import { ProductGridServer } from '../../../widgets/product-grid/ProductGridServer';
-import dynamic from 'next/dynamic';
 import { Metadata } from 'next';
-
-const ClientCatalogShell = dynamic(() => import('./shell').then(m => m.ClientCatalogShell), { ssr: false });
+import { ClientCatalogShell } from './shell';
 
 function readJson<T = any>(candidates: string[]): T | null {
   for (const p of candidates) {

--- a/front/src/app/(shop)/catalog/page.tsx
+++ b/front/src/app/(shop)/catalog/page.tsx
@@ -1,5 +1,4 @@
 import path from 'path';
-import path from 'path';
 import fs from 'fs';
 import React from 'react';
 import { Product } from '../../../entities';

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'PaintHub – E‑commerce',
     description: 'Shop paints and accessories',
-    url: 'https://example.com',
+    url: (process.env.PUBLIC_ORIGIN || 'http://localhost:3000'),
     siteName: 'PaintHub',
     locale: 'en_US',
     type: 'website'

--- a/front/src/app/not-found.tsx
+++ b/front/src/app/not-found.tsx
@@ -1,7 +1,16 @@
-"use client";
 import React from 'react';
-import NotFound from '../views/NotFound';
 
 export default function NotFoundPage() {
-  return <NotFound />;
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="text-center max-w-md mx-auto px-4">
+        <h1 className="text-6xl font-bold text-foreground mb-4">404</h1>
+        <h2 className="text-2xl font-semibold text-foreground mb-4">Page Not Found</h2>
+        <p className="text-foreground-muted mb-8">
+          Oops! The page you're looking for doesn't exist.
+        </p>
+        <a href="/" className="inline-block px-6 py-3 rounded-md bg-primary text-primary-foreground">Return to Home</a>
+      </div>
+    </div>
+  );
 }

--- a/front/src/app/sitemap.ts
+++ b/front/src/app/sitemap.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const base = process.env.PUBLIC_ORIGIN || 'https://example.com';
+  const base = (process.env.PUBLIC_ORIGIN || 'http://localhost:3000').replace(/\/$/, '');
   const items: MetadataRoute.Sitemap = [
     { url: `${base}/`, changeFrequency: 'weekly', priority: 1 },
     { url: `${base}/catalog`, changeFrequency: 'weekly', priority: 0.8 },

--- a/todos/seo_and_csr_fixes.md
+++ b/todos/seo_and_csr_fixes.md
@@ -97,3 +97,8 @@ Update — 2025-09-22
 - Improved CLS/LCP: ProductCard images use decoding="async"; ProductDetail main image uses fetchpriority="high" and eager loading; thumbnails lazy-load.
 - Sitemap: more robust product loading (tries ../server/data and server/data).
 
+Update — 2025-09-22
+- Fixed duplicate import in front/src/app/(shop)/catalog/page.tsx.
+- Updated openGraph.url to use PUBLIC_ORIGIN in front/src/app/layout.tsx.
+- Normalized PUBLIC_ORIGIN usage in front/src/app/sitemap.ts (no trailing slash).
+- Next: run production build and address any remaining SSR/CSR warnings.

--- a/todos/seo_and_csr_fixes.md
+++ b/todos/seo_and_csr_fixes.md
@@ -31,7 +31,7 @@ Changes applied (completed)
   - Status: completed
 
 - Product page SEO improvements:
-  - front/src/app/(shop)/product/[id]/page.tsx — converted to Server Component and added generateMetadata() (reads server/data/products.json)
+  - front/src/app/(shop)/product/[id]/page.tsx ��� converted to Server Component and added generateMetadata() (reads server/data/products.json)
   - front/src/views/product/ProductDetail.tsx — made client component, accepts serverId prop and injects JSON-LD & canonical link
   - front/src/app/sitemap.ts — now includes product pages from server/data/products.json
   - Status: completed
@@ -101,4 +101,5 @@ Update — 2025-09-22
 - Fixed duplicate import in front/src/app/(shop)/catalog/page.tsx.
 - Updated openGraph.url to use PUBLIC_ORIGIN in front/src/app/layout.tsx.
 - Normalized PUBLIC_ORIGIN usage in front/src/app/sitemap.ts (no trailing slash).
-- Next: run production build and address any remaining SSR/CSR warnings.
+- Dev setup stabilized: installed deps, built backend, set envs, started dev servers (front:3000, backend:4000), proxy pointed to 3000.
+- Next: run production build, trace and fix “<Html> should not be imported outside of pages/_document” during /404 prerender, then re-run build.


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user is working on a front-end application with a `front/src/app/not-found` directory and needs to address build issues and configuration problems. The changes focus on stabilizing the development setup and fixing production build errors.

## Code changes

- **Next.js config**: Commented out `outputFileTracingRoot` in `front/next.config.mjs` to avoid interference with app/src special routes
- **404 page**: Completely rewrote `front/src/app/not-found.tsx` as a server component with inline JSX instead of importing external NotFound component
- **Catalog page**: Removed duplicate path import and converted dynamic import to regular import in `front/src/app/(shop)/catalog/page.tsx`
- **Layout metadata**: Updated `openGraph.url` to use `PUBLIC_ORIGIN` environment variable in `front/src/app/layout.tsx`
- **Sitemap**: Normalized `PUBLIC_ORIGIN` usage to remove trailing slashes in `front/src/app/sitemap.ts`
- **Progress tracking**: Updated `todos/seo_and_csr_fixes.md` with latest changes and next steps for production build

These changes address production build issues and prepare the application for proper deployment.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8193e90a94194de6947c39c43111c2d4/curry-lab)

👀 [Preview Link](https://8193e90a94194de6947c39c43111c2d4-curry-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8193e90a94194de6947c39c43111c2d4</projectId>-->
<!--<branchName>curry-lab</branchName>-->